### PR TITLE
Selection of closed lot on sell transaction

### DIFF
--- a/ConfigIBKR_example.py
+++ b/ConfigIBKR_example.py
@@ -33,6 +33,8 @@ IBKR = ibkr.IBKRImporter(
     FeesSuffix='Fees',          # suffix for fees & commisions
     currency = 'CHF',           # main currency
     depositAccount = '',        # put in your checkings account if you want deposit transactions
+    suppressClosedLotPrice=False # Sometimes reports IB an inaccurate lot price.
+                                 # In this case it is better to suppress it and let beancount to match lot
     fpath = 'testIB/ibfq.pk'    # use a pickle dump instead of the API, as it has
                                 # considerable loading times. Set to None for real
                                 # API Flex Query fetching. used mainly for development.

--- a/src/drnukebean/importer/ibkr.py
+++ b/src/drnukebean/importer/ibkr.py
@@ -45,7 +45,8 @@ class IBKRImporter(importer.ImporterProtocol):
                 FeesSuffix='Fees',
                 PnLSuffix='PnL',
                 fpath=None,  # 
-                depositAccount=''
+                depositAccount='',
+                suppressClosedLotPrice=False
                 ):
 
         self.Mainaccount = Mainaccount # main IB account in beancount
@@ -59,7 +60,8 @@ class IBKRImporter(importer.ImporterProtocol):
             # if flex query should not be used online (loading time...)
         self.depositAccount = depositAccount # Cash deposits are usually already covered
             # by checkings account statements. If you want anyway the 
-            # deposit transactions, provide a True value 
+            # deposit transactions, provide a True value
+        self.suppressClosedLotPrice=suppressClosedLotPrice
         self.flag = '*' 
 
     def identify(self, file):
@@ -446,7 +448,7 @@ class IBKRImporter(importer.ImporterProtocol):
                 clo=lots.loc[idx+1]
                 if -clo['quantity'] == row['quantity'] and clo['symbol'] == row['symbol']:
                     cost = position.CostSpec(
-                        number_per=clo['tradePrice'],
+                        number_per=0 if self.suppressClosedLotPrice else clo['tradePrice'],
                         number_total=None,
                         currency=clo['currency'],
                         date=clo['openDateTime'].date(),


### PR DESCRIPTION
Fixes #1 
This fix selects the row next to a sell transaction as the closed lot.

Additionally, optional suppression of trade price of closed lot is possible (sometimes the trade price is inaccurate, and beancount can't match then the lot)