### PR TITLE
Process multiple closed lots per sell transaction

### DIFF
--- a/src/drnukebean/importer/ibkr.py
+++ b/src/drnukebean/importer/ibkr.py
@@ -115,7 +115,7 @@ class IBKRImporter(importer.ImporterProtocol):
         #priceLookup = PriceLookup(existing_entries, config['baseCcy'])
 
 
-        if self.filepath == None:
+        if self.filepath is None:
             # get the report from IB. might take a while, when IB is queuing due to 
             # traffic
             try:


### PR DESCRIPTION
This is a fix for a bug introduced by me in ddf7e70198666544041f2612afce1a26b568630f

One sell transaction can potentially close multiple lots. Example:

```
<Trade currency="USD" symbol="FUTU" description="FUTU HOLDINGS LTD-ADR" dateTime="20210512;132942" tradeDate="20210512" quantity="-12" tradePrice="111" proceeds="1332" ibCommission="-0.0082212" ibCommissionCurrency="USD" notes="P" cost="-1518.255556" buySell="SELL" ibOrderID="74535337" openDateTime="" levelOfDetail="EXECUTION" />
<Lot currency="USD" symbol="FUTU" description="FUTU HOLDINGS LTD-ADR" dateTime="20210512;132942" tradeDate="20210512" quantity="10" tradePrice="126.5355556" proceeds="" ibCommission="" ibCommissionCurrency="" notes="ST" cost="1265.355556" buySell="SELL" ibOrderID="" openDateTime="20210511;120516" levelOfDetail="CLOSED_LOT" />
<Lot currency="USD" symbol="FUTU" description="FUTU HOLDINGS LTD-ADR" dateTime="20210512;132942" tradeDate="20210512" quantity="2" tradePrice="126.45" proceeds="" ibCommission="" ibCommissionCurrency="" notes="ST" cost="252.9" buySell="SELL" ibOrderID="" openDateTime="20210511;120516" levelOfDetail="CLOSED_LOT" />
```
This proposed solution iterates over the lots after the sell transaction, until the summed up quantity of closed lots reaches the quantity in the sell row.